### PR TITLE
Improve build reliability and error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ clean:
 
 # 运行测试示例
 test: $(BIN)
-	$(BIN) hello.kunyu
+	$(BIN) examples/hello.kunyu
 
 # 调试运行模式
 debug: $(BIN)
-	$(BIN) -d hello.kunyu
+	$(BIN) -d examples/hello.kunyu
 
 # 运行交互式REPL
 repl: $(BIN)

--- a/includes/kunyu.h
+++ b/includes/kunyu.h
@@ -6,6 +6,10 @@
 #ifndef KUNYU_H
 #define KUNYU_H
 
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -245,6 +249,11 @@ void builtins_init();
 void builtins_cleanup();
 PyObject* builtins_call(const char *name, PyObject **args, int arg_count);
 bool builtins_is_builtin(const char *name);
+
+/**
+ * 语法分析器接口
+ */
+KunyuError* parser_get_error();
 
 /**
  * REPL接口

--- a/src/main.c
+++ b/src/main.c
@@ -16,9 +16,7 @@
 
 // 函数声明
 struct AstNode* parser_parse(Token *tokens, size_t token_count);
-KunyuError* parser_get_error();
 bool interpreter_execute(AstNode *root);
-KunyuError* interpreter_get_error();
 
 /**
  * 命令行选项
@@ -201,10 +199,10 @@ static const char* token_type_str(KunyuTokenType type) {
  * @param token 标记指针
  */
 static void print_token(const Token *token) {
-    printf("%-10s | %-10s | 行 %-4d | 列 %-4d\n", 
-           token_type_str(token->type), 
-           token->value, 
-           token->line, 
+    printf("%-10s | %-10s | 行 %-4d | 列 %-4d\n",
+           token_type_str(token->type),
+           token->value ? token->value : "",
+           token->line,
            token->column);
 }
 

--- a/src/repl.c
+++ b/src/repl.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <math.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -31,48 +32,6 @@ static void setup_console_utf8() {
     SetConsoleOutputCP(65001);
     SetConsoleCP(65001);
 #endif
-}
-
-/**
- * 打印一个对象的字符串表示
- */
-static void print_object(PyObject *obj) {
-    if (obj == NULL) {
-        printf("null\n");
-        return;
-    }
-    
-    switch (obj->type) {
-        case TYPE_NUMBER: {
-            PyNumberObject *num = (PyNumberObject *)obj;
-            // 检查是否为整数
-            double intpart;
-            if (modf(num->value, &intpart) == 0.0) {
-                printf("%.0f\n", num->value);
-            } else {
-                printf("%g\n", num->value);
-            }
-            break;
-        }
-        case TYPE_STRING: {
-            PyStringObject *str = (PyStringObject *)obj;
-            printf("\"%s\"\n", str->value);
-            break;
-        }
-        case TYPE_LIST: {
-            PyListObject *list = (PyListObject *)list;
-            printf("[列表，长度: %zu]\n", py_list_length(obj));
-            break;
-        }
-        case TYPE_DICT: {
-            PyDictObject *dict = (PyDictObject *)dict;
-            printf("[字典，大小: %zu]\n", py_dict_size(obj));
-            break;
-        }
-        default:
-            printf("[对象]\n");
-            break;
-    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- enable POSIX features globally and expose `parser_get_error` in the public header
- prevent crashes when printing tokens and drop unused REPL object printer
- fix make targets to run example scripts from the correct path

## Testing
- `make test` *(fails: undefined references and linker warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689573d46a788324adb07608920ab707