### PR TITLE
Fix three code bugs

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -211,21 +211,25 @@ static void skip_comment() {
  * 判断是否是字母或下划线
  */
 static bool is_alpha(char c) {
-    return isalpha(c) || c == '_';
+    /* cast to unsigned char to avoid undefined behavior when c is negative */
+    unsigned char uc = (unsigned char)c;
+    return isalpha(uc) || uc == '_';
 }
 
 /**
  * 判断是否是数字
  */
 static bool is_digit(char c) {
-    return isdigit(c);
+    unsigned char uc = (unsigned char)c;
+    return isdigit(uc);
 }
 
 /**
  * 判断是否是字母、数字或下划线
  */
 static bool is_alnum(char c) {
-    return isalnum(c) || c == '_';
+    unsigned char uc = (unsigned char)c;
+    return isalnum(uc) || uc == '_';
 }
 
 /**

--- a/src/objects.c
+++ b/src/objects.c
@@ -266,6 +266,15 @@ static int py_dict_find_index(PyDictObject *dict, PyObject *key) {
             if (strcmp(str_key->value, dict_key->value) == 0) {
                 return i;
             }
+        } else {
+            /* For non-string keys, fall back to pointer equivalence so duplicate
+             * insertions do not create multiple entries referring to the same
+             * object. This prevents unbounded growth of the dictionary when the
+             * language allows objects other than strings to be used as keys.
+             */
+            if (key == dict->items[i].key) {
+                return i;
+            }
         }
     }
     return -1;

--- a/src/repl.c
+++ b/src/repl.c
@@ -128,14 +128,16 @@ static bool execute_and_print(const char *source) {
     // 如果是表达式，添加输出语句
     if (is_expression) {
         // 创建新的源代码，添加输出语句
-        char *new_source = (char *)malloc(strlen(source) + 10);
+        size_t new_len = strlen(source) + 10; /* 额外空间用于 "输出 "、分号及终止符 */
+        char *new_source = (char *)malloc(new_len);
         if (new_source == NULL) {
             fprintf(stderr, "错误: 内存分配失败\n");
             lexer_free();
             return false;
         }
         
-        sprintf(new_source, "输出 %s;", source);
+        /* 使用 snprintf 防止潜在的缓冲区溢出 */
+        snprintf(new_source, new_len, "输出 %s;", source);
         
         // 使用新的源代码重新进行词法分析
         lexer_free();


### PR DESCRIPTION
Addresses undefined behavior in ctype macros, prevents dictionary key duplication, and mitigates a potential buffer overflow.

The `ctype` macros were used with `char` arguments, which can be negative for certain byte values (e.g., UTF-8), leading to undefined behavior. Casting to `unsigned char` resolves this. Dictionary key lookup for non-string types incorrectly allowed duplicate entries for the same object, causing memory bloat; this is fixed by comparing pointer identity. Finally, `sprintf` in the REPL was replaced with `snprintf` to prevent potential buffer overflows when handling user input.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd0f2ef6-cda6-4a89-9332-26dd04e29d2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd0f2ef6-cda6-4a89-9332-26dd04e29d2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

